### PR TITLE
build: get tests working in Go 1.20

### DIFF
--- a/ed2k.go
+++ b/ed2k.go
@@ -9,11 +9,12 @@ Calling Sum() will wait for the hashing goroutines.
 package ed2k
 
 import (
-	"code.google.com/p/go.crypto/md4"
 	"encoding/hex"
 	"hash"
 	"io"
 	"runtime"
+
+	"golang.org/x/crypto/md4"
 )
 
 // The size of the ed2k checksum in bytes.

--- a/ed2k_test.go
+++ b/ed2k_test.go
@@ -3,10 +3,11 @@ package ed2k_test
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/Kovensky/go-ed2k"
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/Jessidhia/go-ed2k"
 )
 
 // A "fake" reader that never writes anything to the []byte.

--- a/ed2ksum/ed2ksum.go
+++ b/ed2ksum/ed2ksum.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/Kovensky/go-ed2k"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/Jessidhia/go-ed2k"
 )
 
 var useNullChunk = flag.Bool("null-chunk", false,

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Jessidhia/go-ed2k
+
+go 1.20
+
+require golang.org/x/crypto v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
+golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=


### PR DESCRIPTION
Gets tests working in Go 1.20

* change `code.google.com/p/go.crypto/md4` -> `golang.org/x/crypto/md4`
* run `go mod init github.com/Jessidhia/go-ed2k && go mod tidy`, change relevant imports

```
$ go test -v ./...
?       github.com/Jessidhia/go-ed2k/ed2ksum    [no test files]
=== RUN   Test
=== PAUSE Test
=== CONT  Test
--- PASS: Test (0.08s)
=== RUN   Example_hexString
--- PASS: Example_hexString (0.00s)
=== RUN   Example_noNullChunk
--- PASS: Example_noNullChunk (0.00s)
PASS
ok      github.com/Jessidhia/go-ed2k    0.081s
```